### PR TITLE
Fix OTA update: deduplicate app.json, add expo-updates, harden deploy…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Instalar dependencias
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Verificar tipos TypeScript
         run: npm run type-check
 
@@ -82,12 +85,29 @@ jobs:
 
       - name: Verificar configuracao EAS
         run: |
-          PROJECT_ID=$(node -e "const c = require('./app.json'); console.log(c.expo?.extra?.eas?.projectId || '')")
-          if [ -z "$PROJECT_ID" ]; then
-            echo "::error::EAS projectId nao configurado em app.json. Execute 'npx eas init' localmente e faça commit do app.json atualizado."
-            exit 1
-          fi
-          echo "EAS projectId: $PROJECT_ID"
+          node -e "
+            const c = require('./app.json');
+            const projectId = c.expo?.extra?.eas?.projectId;
+            const updatesUrl = c.expo?.updates?.url;
+            const runtimeVersion = c.expo?.runtimeVersion;
+
+            if (!projectId) {
+              console.error('::error::EAS projectId nao configurado em app.json (expo.extra.eas.projectId)');
+              process.exit(1);
+            }
+            if (!updatesUrl) {
+              console.error('::error::updates.url nao configurado em app.json (expo.updates.url)');
+              process.exit(1);
+            }
+            if (!runtimeVersion) {
+              console.error('::error::runtimeVersion nao configurado em app.json (expo.runtimeVersion)');
+              process.exit(1);
+            }
+
+            console.log('EAS projectId:', projectId);
+            console.log('Updates URL:', updatesUrl);
+            console.log('Runtime version policy:', JSON.stringify(runtimeVersion));
+          "
 
       - name: Publicar update via EAS
         run: eas update --branch production --message "Deploy ${{ github.sha }}" --non-interactive
@@ -122,7 +142,7 @@ jobs:
         run: |
           PROJECT_ID=$(node -e "const c = require('./app.json'); console.log(c.expo?.extra?.eas?.projectId || '')")
           if [ -z "$PROJECT_ID" ]; then
-            echo "::error::EAS projectId nao configurado em app.json. Execute 'npx eas init' localmente e faça commit do app.json atualizado."
+            echo "::error::EAS projectId nao configurado em app.json. Execute 'npx eas init' localmente e faca commit do app.json atualizado."
             exit 1
           fi
 

--- a/app.json
+++ b/app.json
@@ -30,15 +30,7 @@
       "output": "static",
       "favicon": "./assets/images/favicon.png"
     },
-    "extra": {
-      "eas": {
-        "projectId": "89aa8fa1-4ffa-4d64-aa1b-eb399aa3e07b"
-      }
-    },
-    "updates": {
-      "url": "https://u.expo.dev/89aa8fa1-4ffa-4d64-aa1b-eb399aa3e07b"
-    },
-    "plugins": ["expo-router", "expo-secure-store"],
+    "plugins": ["expo-router", "expo-secure-store", "expo-updates"],
     "experiments": {
       "typedRoutes": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-secure-store": "~14.0.0",
         "expo-splash-screen": "~0.29.0",
         "expo-status-bar": "~2.0.0",
+        "expo-updates": "~0.27.5",
         "nativewind": "^4.0.0",
         "react": "18.3.1",
         "react-hook-form": "^7.50.0",
@@ -8966,6 +8967,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.13.3.tgz",
+      "integrity": "sha512-t+1F1tiDocSot8iSnrn/CjTUMvVvPV2DpafSVcticpbSzMGybEN7wcamO1t18fK7WxGXpZE9gxtd80qwv/LLqQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-image": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.0.7.tgz",
@@ -8983,6 +8990,12 @@
         }
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.14.0.tgz",
+      "integrity": "sha512-xjGfK9dL0B1wLnOqNkX0jM9p48Y0I5xEPzHude28LY67UmamUyAACkqhZGaPClyPNfdzczk7Ej6WaRMT3HfXvw==",
+      "license": "MIT"
+    },
     "node_modules/expo-linking": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-7.0.5.tgz",
@@ -8995,6 +9008,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.15.8.tgz",
+      "integrity": "sha512-VuIyaMfRfLZeETNsRohqhy1l7iZ7I+HKMPfZXVL2Yn17TT0WkOhZoq1DzYwPbOHPgp1Uk6phNa86EyaHrD2DLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~10.0.11",
+        "expo-json-utils": "~0.14.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -9144,6 +9170,56 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.0.0.tgz",
+      "integrity": "sha512-uPiwZjWq3AdFGgY52+I2nGPrNa6izxAglymPXHUZLekZW290GqIUOk7MBNDD4sg4JwUbSi3gdxEurpEvuq+FSg==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.27.5.tgz",
+      "integrity": "sha512-Y771xWW+jRT/pgAwE/BYHEZ4NrY/aSDyqbUABkbzyobQsS03usTwGZb7nadT4f1+x9NbKHxanWtsZeEmWeOx8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/config": "~10.0.11",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.13.3",
+        "expo-manifests": "~0.15.8",
+        "expo-structured-headers": "~4.0.0",
+        "expo-updates-interface": "~1.0.0",
+        "fast-glob": "^3.3.2",
+        "fbemitter": "^3.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.0.0.tgz",
+      "integrity": "sha512-93oWtvULJOj+Pp+N/lpTcFfuREX1wNeHtp7Lwn8EbzYYmdn37MvZU3TPW2tYYCZuhzmKEXnUblYcruYoDu7IrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
     },
     "node_modules/expo/node_modules/expo-file-system": {
       "version": "18.0.12",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "expo-secure-store": "~14.0.0",
     "expo-splash-screen": "~0.29.0",
     "expo-status-bar": "~2.0.0",
+    "expo-updates": "~0.27.5",
     "nativewind": "^4.0.0",
     "react": "18.3.1",
     "react-hook-form": "^7.50.0",


### PR DESCRIPTION
… workflow

Three issues preventing "Publicar OTA Update" from working:

1. app.json had duplicate keys (extra, updates) — JSON parsers only keep the last occurrence, causing silent config loss. Merged into single entries with all required fields.

2. expo-updates was missing from dependencies and plugins — required by eas update to bundle and publish OTA updates. Added via npx expo install expo-updates.

3. deploy.yml verification step only checked projectId — now also validates updates.url and runtimeVersion before publishing. Added lint step to test job for parity with CI pipeline.

https://claude.ai/code/session_01KjkHfzTv95VwGJafAcDjB5