### PR TITLE
Remove job redundante 'Validar antes do Deploy' do workflow de deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,36 +31,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Validar antes do Deploy
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout do repositorio
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Instalar dependencias
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Verificar tipos TypeScript
-        run: npm run type-check
-
-      - name: Executar testes
-        run: npm run test:run
-
   update:
     name: Publicar OTA Update
-    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -115,7 +87,7 @@ jobs:
   build:
     name: Build Nativo (sob demanda)
     if: contains(github.event.head_commit.message, '[build]')
-    needs: test
+    needs: update
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
O job 'test' no deploy.yml re-executava lint, type-check e testes que o CI (ci.yml) ja validou no PR antes do merge. Essa duplicacao adicionava ~10 min extras em cada deploy sem beneficio real, ja que o codigo so chega em main apos aprovacao do CI no PR.

- Remove job 'test' (Validar antes do Deploy) inteiro
- Job 'update' agora executa diretamente sem dependencia de validacao
- Job 'build' agora depende de 'update' (OTA primeiro, build depois)

https://claude.ai/code/session_015MMru9f7Sn8XMQ5w6V31Cn