### PR TITLE
Fix Metro bundling failure: enable package exports for Axios resolution

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -3,4 +3,6 @@ const { withNativeWind } = require("nativewind/metro");
 
 const config = getDefaultConfig(__dirname);
 
+config.resolver.unstable_enablePackageExports = true;
+
 module.exports = withNativeWind(config, { input: "./global.css" });


### PR DESCRIPTION
Metro was resolving Axios via its `main` field (dist/node/axios.cjs), which requires Node.js-only modules (crypto, http, url). Axios 1.x relies on the `exports` field with `react-native` condition to resolve to dist/browser/axios.cjs, but Metro doesn't use `exports` by default.

Enable `unstable_enablePackageExports` in Metro config so it respects the package.json `exports` field and correctly resolves the browser build for React Native.

https://claude.ai/code/session_015MMru9f7Sn8XMQ5w6V31Cn