### PR TITLE
fix: remove empty iOS submit fields from eas.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -24,10 +24,6 @@
   },
   "submit": {
     "production": {
-      "ios": {
-        "ascAppId": "",
-        "appleTeamId": ""
-      },
       "android": {
         "track": "internal",
         "releaseStatus": "draft"


### PR DESCRIPTION
ascAppId and appleTeamId cannot be empty strings — EAS validates them even when submit is not being run. Removed iOS submit config until real values are available.

https://claude.ai/code/session_01CiwsX5YJMi9rEFAsyN1riD