### PR TITLE
feat(sentry): wire real DSN for h4money/cash-mobile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,15 @@
 EXPO_PUBLIC_API_URL=https://api.h4cashback.com
 
 # ── Sentry ─────────────────────────────────────
-# DSN do projeto Sentry (obrigatório em produção)
-SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+# DSN do projeto h4money/cash-mobile (criado 2026-05-09).
+# DSN é público por design (vai no bundle). Mantido vazio em dev pra
+# evitar ruído; em prod, popular via env do build profile.
+SENTRY_DSN=https://d3ba29983a737d4544513fd348b9a11c@o4511361473576961.ingest.us.sentry.io/4511361719271425
+
+# Sentry CI auth token (Organization Auth Token, escopo `org:ci`).
+# Não commitar valor real; em CI vem do secret SENTRY_AUTH_TOKEN.
+# Pra criar: https://h4money.sentry.io/settings/auth-tokens/
+SENTRY_AUTH_TOKEN=
 
 # ── Ambiente ───────────────────────────────────
 # development | preview | production


### PR DESCRIPTION
## Summary

H4 Sentry org `h4money` now exists. Replaces the throwaway placeholder DSN with the real one.

- Project: [`h4money/cash-mobile`](https://h4money.sentry.io/projects/cash-mobile/) (id `4511361719271425`)
- Platform: react-native
- PII scrubbing on: `password`, `senha`, `cpf`, `cnpj`, `cep`, `rg`, `authorization`, `cookie`, IP addresses

## Test plan

- [x] DSN format valid (Sentry React Native SDK accepts)
- [ ] CI green
- [ ] After merge, set repo secret + first build uploads source maps

## Manual follow-up

```bash
gh secret set SENTRY_AUTH_TOKEN --repo H4Alex/cash-mobile --body 'sntrys_...'
```

Same Organization Auth Token (`org:ci`) used in the other H4 repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)